### PR TITLE
Handle disconnects

### DIFF
--- a/src/main/kotlin/exporter/jmx/MBeanConnectorException.kt
+++ b/src/main/kotlin/exporter/jmx/MBeanConnectorException.kt
@@ -1,0 +1,7 @@
+package exporter.jmx
+
+import java.lang.RuntimeException
+
+class MBeanConnectorException(message: String?, cause: Throwable?)
+    : RuntimeException(message, cause) {
+}


### PR DESCRIPTION
For addressing #1:
- Abort gracefully if connection cannot be established
- Collector will try to reconnect to target if it goes down
- Introduce `mbean_up` gauge